### PR TITLE
refactor: use upstream cpython

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,14 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: cpython-3.12.9
-          key: cpython-wasi-3.12.9-wasi-sdk-25.0.0
+          key: python-cpython-wasi-3.12.9-wasi-sdk-25.0.0
       - uses: actions/cache@v4
         with:
           path: cpython-3.13.2
-          key: cpython-wasi-3.13.2-wasi-sdk-25.0.0
+          key: python-cpython-wasi-3.13.2-wasi-sdk-25.0.0
       - uses: actions/cache@v4
         with:
-          path: wasi-sdk
+          path: wasi-sdk-25.0.0
           key: wasi-sdk-25.0.0
       - uses: bytecodealliance/actions/wasmtime/setup@3b93676295fd6f7eaa7af2c2785539e052fa8349
 

--- a/.github/workflows/package_build.yml
+++ b/.github/workflows/package_build.yml
@@ -56,14 +56,14 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: cpython-3.12.9
-          key: cpython-wasi-3.12.9-wasi-sdk-25.0.0
+          key: python-cpython-wasi-3.12.9-wasi-sdk-25.0.0
       - uses: actions/cache@v4
         with:
           path: cpython-3.13.2
-          key: cpython-wasi-3.13.2-wasi-sdk-25.0.0
+          key: python-cpython-wasi-3.13.2-wasi-sdk-25.0.0
       - uses: actions/cache@v4
         with:
-          path: wasi-sdk
+          path: wasi-sdk-25.0.0
           key: wasi-sdk-25.0.0
 
       - run: cargo run -- install-build-tools

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasi-wheels"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "Compile Python wheels for use with WASI targets."
 repository = "https://github.com/benbrandt/wasi-wheels"
 license = "Apache-2.0"

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,6 +1,5 @@
 use std::{env, ffi::OsStr, iter::once, path::PathBuf, sync::LazyLock};
 
-use build_tools::download_wasi_sdk;
 use clap::ValueEnum;
 use sha2::{Digest, Sha256};
 use strum::IntoEnumIterator;
@@ -20,8 +19,6 @@ pub static REPO_DIR: LazyLock<PathBuf> =
 pub static PACKAGES_DIR: LazyLock<PathBuf> = LazyLock::new(|| REPO_DIR.join("packages"));
 /// Directory for storing package index files
 pub static INDEX_DIR: LazyLock<PathBuf> = LazyLock::new(|| REPO_DIR.join("index"));
-/// Directory the Wasi SDK should be setup at
-static WASI_SDK: LazyLock<PathBuf> = LazyLock::new(|| REPO_DIR.join("wasi-sdk"));
 
 /// Downloads and prepares the WASI-SDK for use in compilation steps.
 /// Downloads and compiles a fork of Python 3.12 that can be compiled to WASI for use with componentize-py
@@ -32,8 +29,6 @@ static WASI_SDK: LazyLock<PathBuf> = LazyLock::new(|| REPO_DIR.join("wasi-sdk"))
 /// # Panics
 /// If certain paths are invalid because of failed download
 pub async fn install_build_tools() -> anyhow::Result<()> {
-    // Make sure WASI SDK is available
-    download_wasi_sdk().await?;
     for python_version in PythonVersion::iter() {
         python_version.download_and_compile_cpython().await?;
     }

--- a/src/index/wasi.rs
+++ b/src/index/wasi.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::Path, sync::Arc};
 
 use futures_util::TryStreamExt;
 use itertools::Itertools;
-use octocrab::{models::repos::Asset, Octocrab};
+use octocrab::{Octocrab, models::repos::Asset};
 use reqwest::Client;
 use rinja::Template;
 use tokio::{fs, pin, task::JoinSet};
@@ -207,10 +207,12 @@ mod tests {
 
         let index = fs::read_to_string(dir.join("index.html")).await?;
 
-        assert!(packages
-            .packages
-            .keys()
-            .all(|package| index.contains(&format!("<a href=\"{package}/\">{package}</a>"))));
+        assert!(
+            packages
+                .packages
+                .keys()
+                .all(|package| index.contains(&format!("<a href=\"{package}/\">{package}</a>")))
+        );
 
         // Test individual packages
         for (package, files) in packages.packages {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,13 @@
 
 use std::iter;
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use tokio::process::Command;
 
 mod build;
 mod index;
 
-pub use build::{build_and_publish, install_build_tools, PythonVersion, SupportedProjects};
+pub use build::{PythonVersion, SupportedProjects, build_and_publish, install_build_tools};
 pub use index::{download_package, generate_index};
 
 /// Run a given command with common error handling behavior

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand};
 use wasi_wheels::{
-    build_and_publish, download_package, generate_index, install_build_tools, PythonVersion,
-    SupportedProjects,
+    PythonVersion, SupportedProjects, build_and_publish, download_package, generate_index,
+    install_build_tools,
 };
 
 #[derive(Debug, Parser)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13,7 +13,6 @@ fn install_build_tools() -> anyhow::Result<()> {
 
     assert.success();
 
-    assert!(std::fs::read_dir("wasi-sdk")?.count() > 0);
     assert!(std::fs::read_dir("cpython-3.12.9")?.count() > 0);
     assert!(std::fs::read_dir("cpython-3.13.2")?.count() > 0);
 


### PR DESCRIPTION
Also allow for cpython versions to select their own wasi-sdk version
